### PR TITLE
Add support for ghc 8.10 by relaxing package bounds

### DIFF
--- a/nix-script-haskell/nix-script-haskell.cabal
+++ b/nix-script-haskell/nix-script-haskell.cabal
@@ -20,10 +20,10 @@ executable nix-script-haskell
   main-is:             Main.hs
   -- other-modules:
   -- other-extensions:
-  build-depends:       base >=4.13 && <4.14
-                     , process == 1.6.9.0
-                     , relude == 0.7.0.0
-                     , text == 1.2.4.0
+  build-depends:       base >=4.13 && <4.15
+                     , process ^>= 1.6.9.0
+                     , relude ^>= 0.7.0.0
+                     , text ^>= 1.2.4.0
   -- hs-source-dirs:
   default-language:    Haskell2010
   default-extensions:  OverloadedStrings

--- a/nix-script/nix-script.cabal
+++ b/nix-script/nix-script.cabal
@@ -20,19 +20,19 @@ executable nix-script
   main-is:             Main.hs
   -- other-modules:
   -- other-extensions:
-  build-depends:       base >=4.13 && <4.14
-                     , base16-bytestring == 0.1.1.7
-                     , cryptohash-sha256 == 0.11.101.0
-                     , data-fix == 0.2.1
-                     , directory == 1.3.6.0
-                     , filepath == 1.4.2.1
+  build-depends:       base >=4.13 && <4.15
+                     , base16-bytestring ^>= 0.1.1.7
+                     , cryptohash-sha256 ^>= 0.11.101.0
+                     , data-fix >= 0.2.1 && < 0.4
+                     , directory ^>= 1.3.6.0
+                     , filepath ^>= 1.4.2.1
                      , neat-interpolation
-                     , prettyprinter == 1.6.2
-                     , process == 1.6.9.0
-                     , relude == 0.7.0.0
-                     , hnix == 0.9.1
-                     , text == 1.2.4.0
-                     , utf8-string == 1.0.1.1
+                     , prettyprinter >= 1.6.2 && < 1.8
+                     , process ^>= 1.6.9.0
+                     , relude ^>= 0.7.0.0
+                     , hnix >= 0.9.1 && < 0.13
+                     , text ^>= 1.2.4.0
+                     , utf8-string ^>= 1.0.1.1
   -- hs-source-dirs:
   default-language:    Haskell2010
   default-extensions:  OverloadedStrings


### PR DESCRIPTION
- base has been extended to allow for 4.14
- data-fix, hnix and prettyprinter have been extend to allow the version that is currently in nixpkgs-unstable
- All the other bounds have been replace to `^>=`, which allows minor version increase, giving us some leeway there

I tested these changes with the ghc 8.10 that is in nixpkgs-unstable, and they
work perfectly[1]. These changes allow to compile nix-script in nixpkgs-unstable

[1] Except hnix's tests are currently broken in nixpkgs-unstable for osx, but
the fix is already merged upstream, and everything works after disabling the tests.