### PR TITLE
Allow override pinnedPkgs at the top-level

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,9 +1,9 @@
-{ sources ? import ./nix/sources.nix { }, pkgs ? import sources.nixpkgs { }, ...
-}:
+{ sources ? import ./nix/sources.nix { }, pkgs ? import sources.nixpkgs { }
+, pinnedPkgs ? sources.nixpkgs, ... }:
 pkgs.symlinkJoin {
   name = "nix-script";
   paths = [
-    (pkgs.callPackage ./nix-script { })
+    (pkgs.callPackage ./nix-script { inherit pinnedPkgs; })
     (pkgs.callPackage ./nix-script-bash { })
     (pkgs.callPackage ./nix-script-haskell { })
   ];


### PR DESCRIPTION
This makes it easier to control the nixpkgs version without diving in the internals. Also, I think it matches what's currently documented in the README