### PR TITLE
Relax base16-bytestring bound

### DIFF
--- a/nix-script/nix-script.cabal
+++ b/nix-script/nix-script.cabal
@@ -21,7 +21,7 @@ executable nix-script
   -- other-modules:
   -- other-extensions:
   build-depends:       base >=4.13 && <4.15
-                     , base16-bytestring ^>= 0.1.1.7
+                     , base16-bytestring >= 0.1.1.7 && < 1.1
                      , cryptohash-sha256 ^>= 0.11.101.0
                      , data-fix >= 0.2.1 && < 0.4
                      , directory ^>= 1.3.6.0


### PR DESCRIPTION
This makes it possible to build nix-script on the latest nixpkgs, which contains base16-bytestring 1.0.1.0. I've tested it, and it works.