### PR TITLE
update nix to 21.05

### DIFF
--- a/nix-script/Main.hs
+++ b/nix-script/Main.hs
@@ -229,17 +229,17 @@ deps variousDeps = do
   let source = Text.concat ["[ ", Text.intercalate " " variousDeps, " ]"]
   let result = Nix.Parser.parseNixText source
   case result of
-    Nix.Parser.Success (Fix (NET.NList deps)) -> do
+    Right (Fix (NET.NList deps)) -> do
       let docs = map Nix.Pretty.prettyNix deps
       Right (map (RenderText.renderStrict . Doc.layoutCompact) docs)
-    Nix.Parser.Success node ->
+    Right node ->
       Left
         ( Text.concat
             [ "Internal error: expected a list, but got: ",
               RenderText.renderStrict $ Doc.layoutCompact $ Nix.Pretty.prettyNix node
             ]
         )
-    Nix.Parser.Failure problem ->
+    Left problem ->
       Left
         ( Text.concat
             [ "I had a problem parsing the script's dependencies: ",

--- a/nix-script/nix-script.cabal
+++ b/nix-script/nix-script.cabal
@@ -31,7 +31,7 @@ executable nix-script
                      , prettyprinter >= 1.6.2 && < 1.8
                      , process ^>= 1.6.9.0
                      , relude ^>= 0.7.0.0
-                     , hnix >= 0.9.1 && < 0.13
+                     , hnix >= 0.13.0 && < 0.14
                      , text ^>= 1.2.4.0
                      , utf8-string ^>= 1.0.1.1
   -- hs-source-dirs:

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -24,15 +24,15 @@
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
-        "branch": "release-20.09",
+        "branch": "release-21.05",
         "description": "Nix Packages collection",
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3858fbc08e6c0bc92e0571a006319ff06c9a893a",
-        "sha256": "1b7k9pz8ag3ymwc2ab616ab1ihhv0c00nlgrznnwg3zyp0wry8al",
+        "rev": "86d8a4876235f9600439401efad8b957ea3a5c26",
+        "sha256": "0z5znklnadar0lm3bbnwxyvdhqgbza7i43mg6lpqyava9gffd7p3",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/3858fbc08e6c0bc92e0571a006319ff06c9a893a.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/86d8a4876235f9600439401efad8b957ea3a5c26.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
upgrades nix to 21.05, and starts to consume hnix 0.13.1 which replaces Result with a normal Either

wrt to climate change: I do not own an air conditioner and let me tell you, this PR was a sweaty one
