### PR TITLE
remove upper version bounds of hnix and relude

### DIFF
--- a/nix-script/nix-script.cabal
+++ b/nix-script/nix-script.cabal
@@ -30,8 +30,8 @@ executable nix-script
                      , optparse-applicative
                      , prettyprinter >= 1.6.2 && < 1.8
                      , process ^>= 1.6.9.0
-                     , relude ^>= 0.7.0.0
-                     , hnix >= 0.13.0 && < 0.14
+                     , relude >= 0.7.0.0
+                     , hnix >= 0.13.0
                      , temporary ^>= 1.3
                      , text ^>= 1.2.4.0
                      , utf8-string ^>= 1.0.1.1


### PR DESCRIPTION
Fixes #32 

I had to remove the upper version bounds of `hnix` and `relude`. I am not sure, maybe you want to just "increase" the upper version bounds. Just let me know.