### PR TITLE
make at least one arg required

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -46,8 +46,8 @@ struct Opts {
     #[clap(long("cache-directory"), env("NIX_SCRIPT_CACHE"))]
     cache_directory: Option<PathBuf>,
 
-    /// The script to run, plus any arguments. Any positional arguments after
-    /// the script name will be passed on to the script.
+    /// The script to run (required), plus any arguments (optional). Any positional
+    /// arguments after the script name will be passed on to the script.
     // Note: it'd be better to have a "script" and "args" field separately,
     // but there's a parsing issue in Clap (not a bug, but maybe a bug?) that
     // prevents passing args starting in -- after the script if we do that. See

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,7 +52,7 @@ struct Opts {
     // but there's a parsing issue in Clap (not a bug, but maybe a bug?) that
     // prevents passing args starting in -- after the script if we do that. See
     // https://github.com/clap-rs/clap/issues/1538
-    #[clap(min_values = 1)]
+    #[clap(min_values = 1, required = true)]
     script_and_args: Vec<String>,
 }
 
@@ -138,7 +138,7 @@ impl Opts {
         log::trace!("parsing script and args");
         let mut script_and_args = self.script_and_args.iter();
 
-        let script = PathBuf::from(script_and_args.next().context("I need at least a script name to run, but didn't get one. Please pass that as the first positional argument and try again!")?);
+        let script = PathBuf::from(script_and_args.next().context("I need at least a script name to run, but didn't get one. This represents an internal error, and you should open a bug!")?);
 
         Ok((script, self.script_and_args[1..].to_vec()))
     }


### PR DESCRIPTION
This is now validated in clap instead of in our code, which makes the error messages a bit nicer and more consistent!
