### PR TITLE
run scripts

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -192,8 +192,15 @@ fn main() {
     let opts = Opts::parse();
     log::trace!("opts: {:?}", opts);
 
-    if let Err(err) = opts.run() {
-        eprintln!("{:?}", err);
-        std::process::exit(1)
+    match opts.run().map(|status| status.code()) {
+        Ok(Some(code)) => std::process::exit(code),
+        Ok(None) => {
+            log::warn!("we didn't receive an exit code; was the script killed with a signal?");
+            std::process::exit(1)
+        }
+        Err(err) => {
+            eprintln!("{:?}", err);
+            std::process::exit(1)
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -146,8 +146,6 @@ impl Opts {
             log::debug!("hashed path exists; skipping build");
         }
 
-        // TODO: store in the cache
-
         // TODO: run the executable with the given args
 
         Ok(())


### PR DESCRIPTION
Finally, actually, run the script! Here's how the runtime breaks down at this PR:

```
Benchmark 1: bash sample-scripts/jq.sh
  Time (mean ± σ):      15.8 ms ±   1.3 ms    [User: 13.7 ms, System: 1.5 ms]
  Range (min … max):    14.5 ms …  22.5 ms    164 runs
 
Benchmark 2: ./cache/9ba14df39a87ecaa-jq.sh/bin/jq.sh
  Time (mean ± σ):      17.0 ms ±   0.8 ms    [User: 14.5 ms, System: 1.7 ms]
  Range (min … max):    15.9 ms …  19.5 ms    147 runs
 
Benchmark 3: ./result/bin/nix-script sample-scripts/jq.sh
  Time (mean ± σ):      18.5 ms ±   1.0 ms    [User: 15.3 ms, System: 2.3 ms]
  Range (min … max):    17.4 ms …  22.9 ms    139 runs
 
Summary
  'bash sample-scripts/jq.sh' ran
    1.07 ± 0.10 times faster than './cache/9ba14df39a87ecaa-jq.sh/bin/jq.sh'
    1.17 ± 0.12 times faster than './result/bin/nix-script sample-scripts/jq.sh'
```

So, basically, we get something like 1-2ms of overhead going from plain script to Nix, and then another 1-2ms going from Nix to `nix-script`. I think the program adds enough value to justify a 2-4ms overhead!
