### PR TITLE
add buildRoot and runtimeFiles directives

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -71,13 +71,14 @@ Command-line arguments always take precedence, then shebangs.
 
 *status: partially defined* (needs thought on extra files)
 
-| `#!` line         | Meaning                                      | Notes                                                                                                                |
-|-------------------|----------------------------------------------|----------------------------------------------------------------------------------------------------------------------|
-| `#!build`         | build command for script                     | should read from `$INPUT` and write to `$OUTPUT`. Will be run in the source directory.                               |
-| `#!buildInputs`   | build inputs, as a Nix list                  | e.g. `buildInputs = [ the-thing-you-specify ];`.                                                                     |
-| `#!runtimeInputs` | runtime inputs, as a Nix list                | see note on `buildInputs`.                                                                                           |
-| `#!interpreter`   | interpret "built" binary with this script    | Must be a binary which accepts at least one argument (the build source). Binary must be provided by `runtimeInputs`. |
-| `#!extraSrc`      | a file or directory to include at build time | multiple calls will be merged. Key name still up in the air.                                                         |
+| `#!` line         | Meaning                                       | Notes                                                                                                                |
+|-------------------|-----------------------------------------------|----------------------------------------------------------------------------------------------------------------------|
+| `#!build`         | build command for script                      | should read from `$INPUT` and write to `$OUTPUT`. Will be run in the source directory.                               |
+| `#!buildRoot`     | build step will include all source here       | must be a parent directory of the script                                                                             |
+| `#!buildInputs`   | build inputs, as a Nix list                   | e.g. `buildInputs = [ the-thing-you-specify ];`.                                                                     |
+| `#!runtimeInputs` | runtime inputs, as a Nix list                 | see note on `buildInputs`.                                                                                           |
+| `#!interpreter`   | interpret "built" binary with this script     | Must be a binary which accepts at least one argument (the build source). Binary must be provided by `runtimeInputs`. |
+| `#!runtimeFiles`  | files or directories to include at build time | multiple calls will be merged.                                                                                       |
 
 ### What about environment variables?
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -186,3 +186,14 @@ For example:
   "runtime_inputs": []
 }
 ```
+
+## Runtime Variables
+
+*status: partially defined* (and partially implemented)
+
+We set some environment variables that the script can access at runtime:
+
+| Variable             | Meaning                                                                                                            |
+|----------------------|--------------------------------------------------------------------------------------------------------------------|
+| `RUNTIME_FILES_ROOT` | If `#!runtimeFiles` or `--runtime-files` was specified, this is set to where we put them.                          |
+| `SCRIPT_FILE`        | the name of the script as originally invoked (name is awkward but remains for compatibility with nix-script 1.0.0) |

--- a/SPEC.md
+++ b/SPEC.md
@@ -69,7 +69,7 @@ Command-line arguments always take precedence, then shebangs.
 
 ### Keys Accepted
 
-*status: partially defined* (needs thought on extra files)
+*status: implemented*
 
 | `#!` line         | Meaning                                       | Notes                                                                                                                |
 |-------------------|-----------------------------------------------|----------------------------------------------------------------------------------------------------------------------|
@@ -80,7 +80,7 @@ Command-line arguments always take precedence, then shebangs.
 | `#!interpreter`   | interpret "built" binary with this script     | Must be a binary which accepts at least one argument (the build source). Binary must be provided by `runtimeInputs`. |
 | `#!runtimeFiles`  | files or directories to include at build time | multiple calls will be merged.                                                                                       |
 
-### What about environment variables?
+### What about environment variables as inputs?
 
 *status: speculative*
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -99,7 +99,7 @@ Items that are expressions are left alone and items that appear to be references
 
 *status: implemented*
 
-Running `nix-script --export --root path/to path/to/script.sh` will print the derivation to stdout instead of building it.
+Running `nix-script --export --build-root path/to path/to/script.sh` will print the derivation to stdout instead of building it.
 We intend here to provide a mechanism for things like import-from-derivation.
 
 ## Caching
@@ -128,7 +128,7 @@ The hash includes:
 
 - the bytes of the script source
 - the directives calculated between script source and command-line flags
-- bytes of any files in the file specified by `--root`
+- bytes of any files in the file specified by `--build-root`
 
 ## Shell mode
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -91,6 +91,9 @@ impl Builder {
         log::trace!("adding runtime inputs");
         derivation.add_runtime_inputs(directives.runtime_inputs.clone());
 
+        log::trace!("adding runtime files");
+        derivation.add_runtime_files(directives.runtime_files.clone());
+
         if let Some(interpreter) = &directives.interpreter {
             log::debug!("using interpreter from directives");
             derivation

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -62,11 +62,6 @@ impl Builder {
         })
     }
 
-    pub fn directives(&self, indicator: &str) -> Result<Directives> {
-        let source = self.source.read()?;
-        Directives::parse(indicator, &source).context("could not construct a directive parser")
-    }
-
     pub fn derivation(&self, directives: &Directives, for_export: bool) -> Result<Derivation> {
         let build_command = match &directives.build_command {
             Some(bc) => bc,
@@ -203,16 +198,6 @@ enum Source {
 }
 
 impl Source {
-    fn read(&self) -> Result<String> {
-        log::trace!("reading script source");
-        match self {
-            Self::Script { script, .. } => fs::read_to_string(&script)
-                .with_context(|| format!("could not read {}", script.display())),
-            Self::Directory { root, script, .. } => fs::read_to_string(root.join(script))
-                .with_context(|| format!("could not read {}", script.display())),
-        }
-    }
-
     fn root(&self) -> Result<&Path> {
         match self {
             Self::Script {

--- a/src/derivation/mod.rs
+++ b/src/derivation/mod.rs
@@ -187,6 +187,14 @@ impl Display for Derivation {
             )?
         }
 
+        if !self.runtime_files.is_empty() {
+            write!(
+                f,
+                " \\\n        --set RUNTIME_FILES_ROOT $out/usr/share/{}",
+                self.name
+            )?;
+        }
+
         if !self.runtime_inputs.is_empty() {
             write!(f, " \\\n        --prefix PATH : ${{pkgs.lib.makeBinPath ")?;
             fmt_list(f, &self.runtime_inputs)?;

--- a/src/derivation/mod.rs
+++ b/src/derivation/mod.rs
@@ -33,7 +33,10 @@ impl Derivation {
         );
 
         Ok(Self {
-            inputs: Inputs::from(vec![("pkgs".into(), Some("import <nixpkgs> { }".into()))]),
+            inputs: Inputs::from(vec![
+                ("pkgs".into(), Some("import <nixpkgs> { }".into())),
+                ("makeWrapper".into(), Some("pkgs.makeWrapper".into())),
+            ]),
             name: src
                 .file_name()
                 .and_then(|name| name.to_str())
@@ -80,15 +83,10 @@ impl Derivation {
             },
         ));
 
-        log::debug!("depending on makeWrapper since we have an interpreter");
-        self.depend_on_make_wrapper();
-
         Ok(())
     }
 
     pub fn add_runtime_inputs(&mut self, runtime_inputs: Vec<Expr>) {
-        log::debug!("depending on makeWrapper since we have runtime inputs");
-        self.depend_on_make_wrapper();
         for runtime_input in runtime_inputs {
             if runtime_input.is_extractable() {
                 log::trace!("extracting build input `{}`", runtime_input);
@@ -99,13 +97,6 @@ impl Derivation {
             }
             self.runtime_inputs.insert(runtime_input);
         }
-    }
-
-    fn depend_on_make_wrapper(&mut self) {
-        self.inputs.insert(
-            "makeWrapper".to_string(),
-            Some("pkgs.makeWrapper".to_string()),
-        );
     }
 }
 

--- a/src/derivation/mod.rs
+++ b/src/derivation/mod.rs
@@ -152,7 +152,7 @@ impl Display for Derivation {
 
         if !self.runtime_files.is_empty() {
             let target: PathBuf = ["$out", "usr", "share", &self.name].iter().collect();
-            write!(f, "\n\n    mkdir {}", target.display())?;
+            write!(f, "\n\n    mkdir -p {}", target.display())?;
             for file in &self.runtime_files {
                 write!(f, "\n    mv {} {}", &file.display(), target.display())?;
             }

--- a/src/directives/mod.rs
+++ b/src/directives/mod.rs
@@ -13,7 +13,7 @@ pub struct Directives {
     pub build_inputs: Vec<Expr>,
     pub interpreter: Option<String>,
     pub runtime_inputs: Vec<Expr>,
-    pub root: Option<PathBuf>,
+    pub build_root: Option<PathBuf>,
 }
 
 impl Directives {
@@ -34,14 +34,14 @@ impl Directives {
         let build_inputs = Self::exprs("buildInputs", &fields)?;
         let interpreter = Self::once("interpreter", &fields)?.map(|s| s.to_owned());
         let runtime_inputs = Self::exprs("runtimeInputs", &fields)?;
-        let root = Self::once("root", &fields)?.map(PathBuf::from);
+        let build_root = Self::once("buildRoot", &fields)?.map(PathBuf::from);
 
         Ok(Directives {
             build_command,
             build_inputs,
             interpreter,
             runtime_inputs,
-            root,
+            build_root,
         })
     }
 
@@ -104,8 +104,8 @@ impl Hash for Directives {
             input.hash(hasher)
         }
 
-        if let Some(root) = &self.root {
-            hasher.write(root.display().to_string().as_ref())
+        if let Some(build_root) = &self.build_root {
+            hasher.write(build_root.display().to_string().as_ref())
         }
     }
 }
@@ -173,12 +173,13 @@ mod tests {
         }
 
         #[test]
-        fn only_one_root_allowed() {
+        fn only_one_build_root_allowed() {
             let problem =
-                Directives::from_directives(HashMap::from([("root", vec!["a", "b"])])).unwrap_err();
+                Directives::from_directives(HashMap::from([("buildRoot", vec!["a", "b"])]))
+                    .unwrap_err();
 
             assert_eq!(
-                String::from("I got multiple `root` directives, and I don't know which to use. Remove all but one and try again!"),
+                String::from("I got multiple `buildRoot` directives, and I don't know which to use. Remove all but one and try again!"),
                 problem.to_string(),
             )
         }
@@ -186,9 +187,9 @@ mod tests {
         #[test]
         fn sets_root() {
             let directives =
-                Directives::from_directives(HashMap::from([("root", vec!["."])])).unwrap();
+                Directives::from_directives(HashMap::from([("buildRoot", vec!["."])])).unwrap();
 
-            assert_eq!(Some(PathBuf::from(".")), directives.root)
+            assert_eq!(Some(PathBuf::from(".")), directives.build_root)
         }
     }
 
@@ -244,8 +245,8 @@ mod tests {
         #[test]
         fn root_changes_hash() {
             assert_have_different_hashes(
-                Directives::from_directives(HashMap::from([("root", vec!["a"])])).unwrap(),
-                Directives::from_directives(HashMap::from([("root", vec!["b"])])).unwrap(),
+                Directives::from_directives(HashMap::from([("buildRoot", vec!["a"])])).unwrap(),
+                Directives::from_directives(HashMap::from([("buildRoot", vec!["b"])])).unwrap(),
             )
         }
     }

--- a/src/directives/mod.rs
+++ b/src/directives/mod.rs
@@ -82,7 +82,7 @@ impl Directives {
     ) -> Vec<PathBuf> {
         match fields.get(field) {
             None => Vec::new(),
-            Some(lines) => lines.join(" ").split(" ").map(PathBuf::from).collect(),
+            Some(lines) => lines.join(" ").split(' ').map(PathBuf::from).collect(),
         }
     }
 
@@ -98,9 +98,9 @@ impl Directives {
         }
     }
 
-    pub fn merge_runtime_files(&mut self, new: &Vec<PathBuf>) {
+    pub fn merge_runtime_files(&mut self, new: &[PathBuf]) {
         for item in new {
-            if !self.runtime_files.contains(&item) {
+            if !self.runtime_files.contains(item) {
                 self.runtime_files.push(item.to_owned())
             }
         }

--- a/src/directives/mod.rs
+++ b/src/directives/mod.rs
@@ -107,6 +107,65 @@ impl Hash for Directives {
 mod tests {
     use super::*;
 
+    mod from_directives {
+        use super::*;
+
+        #[test]
+        fn only_one_build_command_allowed() {
+            let problem = Directives::from_directives(HashMap::from([("build", vec!["a", "b"])]))
+                .unwrap_err();
+
+            assert_eq!(
+                String::from("I got multiple build directives, and I don't know which to use. Remove all but one and try again!"),
+                problem.to_string(),
+            )
+        }
+
+        #[test]
+        fn combines_build_inputs() {
+            let directives =
+                Directives::from_directives(HashMap::from([("buildInputs", vec!["a b", "c d"])]))
+                    .unwrap();
+
+            let expected: Vec<Expr> = vec![
+                Expr::parse("a").unwrap(),
+                Expr::parse("b").unwrap(),
+                Expr::parse("c").unwrap(),
+                Expr::parse("d").unwrap(),
+            ];
+
+            assert_eq!(expected, directives.build_inputs);
+        }
+
+        #[test]
+        fn only_one_interpreter_allowed() {
+            let problem =
+                Directives::from_directives(HashMap::from([("interpreter", vec!["a", "b"])]))
+                    .unwrap_err();
+
+            assert_eq!(
+                String::from("I got multiple interpreter directives, and I don't know which to use. Remove all but one and try again!"),
+                problem.to_string(),
+            )
+        }
+
+        #[test]
+        fn combines_runtime_inputs() {
+            let directives =
+                Directives::from_directives(HashMap::from([("runtimeInputs", vec!["a b", "c d"])]))
+                    .unwrap();
+
+            let expected: Vec<Expr> = vec![
+                Expr::parse("a").unwrap(),
+                Expr::parse("b").unwrap(),
+                Expr::parse("c").unwrap(),
+                Expr::parse("d").unwrap(),
+            ];
+
+            assert_eq!(expected, directives.runtime_inputs);
+        }
+    }
+
     mod hash {
         use super::*;
 

--- a/src/directives/mod.rs
+++ b/src/directives/mod.rs
@@ -102,3 +102,58 @@ impl Hash for Directives {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    mod hash {
+        use super::*;
+
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+
+        fn assert_have_different_hashes<H: Hash>(l: H, r: H) {
+            let mut l_hasher = DefaultHasher::new();
+            let mut r_hasher = DefaultHasher::new();
+
+            l.hash(&mut l_hasher);
+            r.hash(&mut r_hasher);
+
+            println!("l: {}, r: {}", l_hasher.finish(), r_hasher.finish());
+            assert!(l_hasher.finish() != r_hasher.finish())
+        }
+
+        #[test]
+        fn build_command_changes_hash() {
+            assert_have_different_hashes(
+                Directives::from_directives(HashMap::from([("build", vec!["a"])])).unwrap(),
+                Directives::from_directives(HashMap::from([("build", vec!["b"])])).unwrap(),
+            )
+        }
+
+        #[test]
+        fn build_inputs_changes_hash() {
+            assert_have_different_hashes(
+                Directives::from_directives(HashMap::from([("buildInputs", vec!["a"])])).unwrap(),
+                Directives::from_directives(HashMap::from([("buildInputs", vec!["b"])])).unwrap(),
+            )
+        }
+
+        #[test]
+        fn interpreter_changes_hash() {
+            assert_have_different_hashes(
+                Directives::from_directives(HashMap::from([("interpreter", vec!["a"])])).unwrap(),
+                Directives::from_directives(HashMap::from([("interpreter", vec!["b"])])).unwrap(),
+            )
+        }
+
+        #[test]
+        fn runtime_inputs_changes_hash() {
+            assert_have_different_hashes(
+                Directives::from_directives(HashMap::from([("runtimeInputs", vec!["a"])])).unwrap(),
+                Directives::from_directives(HashMap::from([("runtimeInputs", vec!["b"])])).unwrap(),
+            )
+        }
+    }
+}

--- a/src/directives/mod.rs
+++ b/src/directives/mod.rs
@@ -10,10 +10,10 @@ use std::path::PathBuf;
 #[derive(Debug, serde::Serialize)]
 pub struct Directives {
     pub build_command: Option<String>,
+    pub build_root: Option<PathBuf>,
     pub build_inputs: Vec<Expr>,
     pub interpreter: Option<String>,
     pub runtime_inputs: Vec<Expr>,
-    pub build_root: Option<PathBuf>,
 }
 
 impl Directives {
@@ -31,17 +31,17 @@ impl Directives {
 
     fn from_directives(fields: HashMap<&str, Vec<&str>>) -> Result<Self> {
         let build_command = Self::once("build", &fields)?.map(|s| s.to_owned());
+        let build_root = Self::once("buildRoot", &fields)?.map(PathBuf::from);
         let build_inputs = Self::exprs("buildInputs", &fields)?;
         let interpreter = Self::once("interpreter", &fields)?.map(|s| s.to_owned());
         let runtime_inputs = Self::exprs("runtimeInputs", &fields)?;
-        let build_root = Self::once("buildRoot", &fields)?.map(PathBuf::from);
 
         Ok(Directives {
             build_command,
+            build_root,
             build_inputs,
             interpreter,
             runtime_inputs,
-            build_root,
         })
     }
 

--- a/src/directives/mod.rs
+++ b/src/directives/mod.rs
@@ -4,6 +4,7 @@ use crate::expr::Expr;
 use anyhow::{Context, Result};
 use core::hash::{Hash, Hasher};
 use std::collections::HashMap;
+use std::path::Path;
 use std::path::PathBuf;
 
 #[derive(Debug, serde::Serialize)]
@@ -16,6 +17,11 @@ pub struct Directives {
 }
 
 impl Directives {
+    pub fn from_file(indicator: &str, filename: &Path) -> Result<Self> {
+        let source = std::fs::read_to_string(filename).context("could not read source")?;
+        Self::parse(indicator, &source)
+    }
+
     pub fn parse(indicator: &str, source: &str) -> Result<Self> {
         let parser = parser::Parser::new(indicator).context("could not construct a parser")?;
         let fields = parser.parse(source);

--- a/src/directives/mod.rs
+++ b/src/directives/mod.rs
@@ -46,7 +46,7 @@ impl Directives {
         let interpreter = match fields.get("interpreter") {
             Some(value) => {
                 if value.len() != 1 {
-                    anyhow::bail!("I got multiple interpreter directives, and I don't known which to use. Remove all but one and try agagin!");
+                    anyhow::bail!("I got multiple interpreter directives, and I don't know which to use. Remove all but one and try again!");
                 }
 
                 Some(value[0].to_owned())

--- a/src/directives/mod.rs
+++ b/src/directives/mod.rs
@@ -97,6 +97,14 @@ impl Directives {
             self.interpreter = maybe_new.to_owned()
         }
     }
+
+    pub fn merge_runtime_files(&mut self, new: &Vec<PathBuf>) {
+        for item in new {
+            if !self.runtime_files.contains(&item) {
+                self.runtime_files.push(item.to_owned())
+            }
+        }
+    }
 }
 
 impl Hash for Directives {

--- a/src/directives/mod.rs
+++ b/src/directives/mod.rs
@@ -24,24 +24,9 @@ impl Directives {
 
     fn from_directives(fields: HashMap<&str, Vec<&str>>) -> Result<Self> {
         let build_command = Self::once("build", &fields)?.map(|s| s.to_owned());
-
-        // buildInputs (many)
-        let build_inputs = match fields.get("buildInputs") {
-            None => Vec::new(),
-            Some(lines) => {
-                Expr::parse_as_list(&lines.join(" ")).context("could not parse build inputs")?
-            }
-        };
-
+        let build_inputs = Self::exprs("buildInputs", &fields)?;
         let interpreter = Self::once("interpreter", &fields)?.map(|s| s.to_owned());
-
-        // runtimeInputs (many)
-        let runtime_inputs = match fields.get("runtimeInputs") {
-            None => Vec::new(),
-            Some(lines) => {
-                Expr::parse_as_list(&lines.join(" ")).context("could not parse runtime inputs")?
-            }
-        };
+        let runtime_inputs = Self::exprs("runtimeInputs", &fields)?;
 
         Ok(Directives {
             build_command,
@@ -64,6 +49,18 @@ impl Directives {
                 Ok(Some(value[0]))
             }
             None => Ok(None),
+        }
+    }
+
+    fn exprs<'field>(
+        field: &'field str,
+        fields: &HashMap<&'field str, Vec<&'field str>>,
+    ) -> Result<Vec<Expr>> {
+        match fields.get(field) {
+            None => Ok(Vec::new()),
+            Some(lines) => {
+                Expr::parse_as_list(&lines.join(" ")).context("could not parse runtime inputs")
+            }
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -102,6 +102,17 @@ impl Opts {
                 build_root = Some(out);
             }
         };
+        if build_root.is_none()
+            && (!self.runtime_files.is_empty() || !directives.runtime_files.is_empty())
+        {
+            log::warn!("Requested runtime files without specifying a build root. I'm assuming it's the parent directory of the script for now, but you should set it explicitly!");
+            build_root = Some(
+                script
+                    .parent()
+                    .map(|p| p.to_owned())
+                    .unwrap_or_else(|| PathBuf::from(".")),
+            );
+        }
 
         let mut builder = if let Some(build_root) = &build_root {
             Builder::from_directory(build_root, &script)

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,7 +84,9 @@ impl Opts {
         directives.maybe_override_build_command(&self.build_command);
         directives.maybe_override_interpreter(&self.interpreter);
 
-        let mut builder = if let Some(root) = &self.root {
+        let root = self.root.as_ref().or(directives.root.as_ref());
+
+        let mut builder = if let Some(root) = &root {
             Builder::from_directory(root, &script)
                 .context("could not initialize source in directory")?
         } else {
@@ -107,7 +109,7 @@ impl Opts {
             // We check here instead of inside while isolating the script or
             // similar so we can get an early bail that doesn't create trash
             // in the system's temporary directories.
-            if self.root.is_none() {
+            if root.is_none() {
                 anyhow::bail!(
                     "I don't have a root to refer to while exporting, so I can't isolate the script and dependencies. Specify a --root and try this again!"
                 )

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ use std::fs;
 use std::io::ErrorKind;
 use std::os::unix::fs::symlink;
 use std::os::unix::process::ExitStatusExt;
-use std::path::{Component, Path, PathBuf};
+use std::path::{Path, PathBuf};
 use std::process::{Command, ExitStatus};
 
 // TODO: options for the rest of the directives

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,6 +48,10 @@ struct Opts {
     #[clap(long)]
     build_root: Option<PathBuf>,
 
+    /// Include files for use at runtime (relative to the build root)
+    #[clap(long)]
+    runtime_files: Vec<PathBuf>,
+
     /// Where should we cache files?
     #[clap(long("cache-directory"), env("NIX_SCRIPT_CACHE"))]
     cache_directory: Option<PathBuf>,
@@ -81,8 +85,10 @@ impl Opts {
         let mut directives = Directives::from_file(&self.indicator, &script)
             .context("could not parse directives from script")?;
 
+        // TODO: do we need build root here?
         directives.maybe_override_build_command(&self.build_command);
         directives.maybe_override_interpreter(&self.interpreter);
+        directives.merge_runtime_files(&self.runtime_files);
 
         let mut build_root = self.build_root.to_owned();
         if build_root.is_none() {

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -97,9 +97,9 @@ mod io_behavior {
     }
 
     #[test]
-    fn include_source_root() {
+    fn include_runtime_file() {
         bin()
-            .arg("tests/with_root/script.sh")
+            .arg("tests/with_runtime_file/script.sh")
             .assert()
             .success()
             .stdout("Hello, World!");

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -95,4 +95,13 @@ mod io_behavior {
             .assert()
             .success();
     }
+
+    #[test]
+    fn include_source_root() {
+        bin()
+            .arg("tests/with_root/script.sh")
+            .assert()
+            .success()
+            .stdout("Hello, World!");
+    }
 }

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -102,6 +102,6 @@ mod io_behavior {
             .arg("tests/with_runtime_file/script.sh")
             .assert()
             .success()
-            .stdout("Hello, World!");
+            .stdout("Hello, World!\n");
     }
 }

--- a/tests/with_root/script.sh
+++ b/tests/with_root/script.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env nix-script
+#!build cp $SRC $OUT
+#!interpreter bash
+#!runtimeInputs coreutils
+#!root .
+set -exuo pipefail
+
+HERE="$(dirname "$(realpath $0)")"
+cat $HERE/message

--- a/tests/with_runtime_file/message
+++ b/tests/with_runtime_file/message
@@ -1,0 +1,1 @@
+Hello, World!

--- a/tests/with_runtime_file/script.sh
+++ b/tests/with_runtime_file/script.sh
@@ -2,9 +2,7 @@
 #!buildRoot .
 #!build cp $SRC $OUT
 #!interpreter bash
-#!runtimeInputs coreutils
 #!runtimeFiles message
-set -exuo pipefail
+set -euo pipefail
 
-HERE="$(dirname "$(realpath $0)")"
-cat $HERE/message
+cat "$RUNTIME_FILES_ROOT/message"

--- a/tests/with_runtime_file/script.sh
+++ b/tests/with_runtime_file/script.sh
@@ -2,6 +2,7 @@
 #!build cp $SRC $OUT
 #!interpreter bash
 #!runtimeInputs coreutils
+#!runtimeFiles message
 #!root .
 set -exuo pipefail
 

--- a/tests/with_runtime_file/script.sh
+++ b/tests/with_runtime_file/script.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env nix-script
+#!buildRoot .
 #!build cp $SRC $OUT
 #!interpreter bash
 #!runtimeInputs coreutils
 #!runtimeFiles message
-#!root .
 set -exuo pipefail
 
 HERE="$(dirname "$(realpath $0)")"


### PR DESCRIPTION
makes us better citizens of the Nix ecosystem for eventual nix-script ejection.