### PR TITLE
pull the overlay out of `eachDefaultSystem`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -11,83 +11,97 @@
   };
 
   outputs = inputs:
-    inputs.flake-utils.lib.eachDefaultSystem (system:
-      let
-        pkgs = import inputs.nixpkgs { inherit system; };
-        naersk-lib = inputs.naersk.lib."${system}";
+    let
+      rustTarget = { name, version, pkgs, naersk-lib, postInstall ? "" }:
+        naersk-lib.buildPackage {
+          inherit name;
+          inherit version;
+          inherit postInstall;
 
-        rustTarget = { name, version, postInstall ? "" }:
-          naersk-lib.buildPackage {
-            inherit name;
-            inherit version;
-            inherit postInstall;
+          root = ./.;
 
-            root = ./.;
+          buildInputs = [ pkgs.clippy pkgs.makeWrapper ];
+          target = [ name ];
 
-            buildInputs = [ pkgs.clippy pkgs.makeWrapper ];
-            target = [ name ];
+          doCheck = true;
+          checkPhase = ''
+            cargo clippy -- --deny warnings
 
-            doCheck = true;
-            checkPhase = ''
-              cargo clippy -- --deny warnings
-
-              # make sure we've listed the right version here (we can't grab
-              # it from the manifest because we use a virtual manifest for the
-              # various targets.) If this test fails, fix by making the `version`
-              # attribute the same as the one in `nix-script/Cargo.toml`
-              grep -q -e 'version = "${version}"' ${name}/Cargo.toml
-            '';
-
-            copyBinsFilter = ''
-              select(.reason == "compiler-artifact" and .executable != null and .profile.test == false and .target.name == "${name}")'';
-          };
-      in rec {
-        packages = {
-          nix-script-all = pkgs.symlinkJoin {
-            name = "nix-script-all";
-            paths = [
-              packages.nix-script
-              packages.nix-script-haskell
-              packages.nix-script-bash
-            ];
-          };
-
-          nix-script = rustTarget {
-            name = "nix-script";
-            version = "2.0.0";
-          };
-
-          nix-script-bash = pkgs.writeShellScriptBin "nix-script-bash" ''
-            exec ${packages.nix-script}/bin/nix-script \
-              --build-command 'cp $SRC $OUT' \
-              --interpreter bash \
-              "$@"
+            # make sure we've listed the right version here (we can't grab
+            # it from the manifest because we use a virtual manifest for the
+            # various targets.) If this test fails, fix by making the `version`
+            # attribute the same as the one in `nix-script/Cargo.toml`
+            grep -q -e 'version = "${version}"' ${name}/Cargo.toml
           '';
 
-          nix-script-haskell = rustTarget rec {
-            name = "nix-script-haskell";
-            version = "2.0.0";
-
-            postInstall = ''
-              # avoid trying to package the dependencies step
-              if test -f $out/bin/${name}; then
-                wrapProgram $out/bin/${name} \
-                  --prefix PATH : ${
-                    pkgs.lib.makeBinPath [ packages.nix-script ]
-                  }
-              fi
-            '';
-          };
+          copyBinsFilter = ''
+            select(.reason == "compiler-artifact" and .executable != null and .profile.test == false and .target.name == "${name}")'';
         };
 
-        defaultPackage = packages.nix-script-all;
+      mkNixScript = pkgs: naersk-lib: rustTarget {
+        name = "nix-script";
+        version = "2.0.0";
+        inherit pkgs;
+        inherit naersk-lib;
+      };
 
-        overlay = final: prev: {
-          nix-script-all = packages.nix-script-all;
-          nix-script = packages.nix-script;
-          nix-script-bash = packages.nix-script-bash;
-          nix-script-haskell = packages.nix-script-haskell;
+      mkNixScriptBash = pkgs: pkgs.writeShellScriptBin "nix-script-bash" ''
+        exec ${pkgs.nix-script}/bin/nix-script \
+          --build-command 'cp $SRC $OUT' \
+          --interpreter bash \
+          "$@"
+      '';
+
+      mkNixScriptHaskell = pkgs: naersk-lib: rustTarget rec {
+        name = "nix-script-haskell";
+        version = "2.0.0";
+        inherit pkgs;
+        inherit naersk-lib;
+
+        postInstall = ''
+          # avoid trying to package the dependencies step
+          if test -f $out/bin/${name}; then
+            wrapProgram $out/bin/${name} \
+              --prefix PATH : ${
+                pkgs.lib.makeBinPath [ pkgs.nix-script ]
+              }
+          fi
+        '';
+      };
+
+      mkNixScriptAll = pkgs: pkgs.symlinkJoin {
+        name = "nix-script-all";
+        paths = [
+          pkgs.nix-script
+          pkgs.nix-script-haskell
+          pkgs.nix-script-bash
+        ];
+      };
+    in
+    {
+      overlay = final: prev:
+        let naersk-lib = inputs.naersk.lib."${final.system}"; in
+        {
+          nix-script = mkNixScript prev naersk-lib;
+          nix-script-bash = mkNixScriptBash prev;
+          nix-script-haskell = mkNixScriptHaskell prev naersk-lib;
+          nix-script-all = mkNixScriptAll prev;
         };
+    } // inputs.flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import inputs.nixpkgs {
+          inherit system;
+          overlays = [ inputs.self.overlay ];
+        }; in
+      {
+        packages = {
+          nix-script = pkgs.nix-script;
+          nix-script-bash = pkgs.nix-script-bash;
+          nix-script-haskell = pkgs.nix-script-haskell;
+          nix-script-all = pkgs.nix-script-all;
+        };
+
+        defaultPackage = pkgs.nix-script-all;
 
         devShell = pkgs.mkShell {
           NIX_PKGS = inputs.nixpkgs;

--- a/flake.nix
+++ b/flake.nix
@@ -83,7 +83,7 @@
           nix-script = mkNixScript prev naersk-lib;
           nix-script-bash = mkNixScriptBash prev;
           nix-script-haskell = mkNixScriptHaskell prev naersk-lib;
-          nix-script-all = mkNixScriptAll prev;
+          nix-script-all = mkNixScriptAll final;
         };
     } // inputs.flake-utils.lib.eachDefaultSystem (system:
       let


### PR DESCRIPTION
fixes #76: "error: All overlays passed to nixpkgs must be functions."

I apologize for this oversized PR which actually doesn't change anything
substantial, and only fixes an error. However, when pulling out the
overlay, various problems arouse:

The `pkgs` attribute (and sometimes also the `naersk-lib` attribute) has
to be provided to the functions creating the targets. So those elements
became functions, and I renamed them to `mkNixBla`.

The overlay becomes a bit more complicated because it has to access the
`prev` package set, and call the `mkNixBla` functions with `naersk-lib`.

One positive thing about the overlay being outside is that it can be
used by the `packages` output of the flake itself.

Of course, I am happy to add changes from your side! Maybe you find also
a better solution to this problem!