### PR TITLE
fix build failure (needless borrow)

### DIFF
--- a/nix-script/src/main.rs
+++ b/nix-script/src/main.rs
@@ -247,7 +247,7 @@ impl Opts {
                 .build(&cache_directory, &hash, &directives)
                 .context("could not build derivation from script")?;
 
-            if let Err(err) = symlink(&out_path, &target) {
+            if let Err(err) = symlink(out_path, &target) {
                 match err.kind() {
                     ErrorKind::AlreadyExists => {
                         // we could hypothetically detect if the link is


### PR DESCRIPTION
Hi!

When building with `nixpkgs-unstable-small`, revision `c85d08692966cf022b0a741a794cb1650602d8af`, a build error occurs. (Needless borrow). This PR fixes this build error. However, I do not know if this works with older versions of rust. Maybe the CI is enough to answer this question?