### PR TITLE
Fix pedantic errors on rustc nightly

### DIFF
--- a/directives/src/expr.rs
+++ b/directives/src/expr.rs
@@ -15,7 +15,7 @@ pub struct Expr {
 
 impl Expr {
     pub fn parse_as_list(source: &str) -> Result<Vec<Self>> {
-        let root = rnix::parse(&format!("[{}]", source))
+        let root = rnix::parse(&format!("[{source}]"))
             .as_result()
             .context("failed to parse the source when wrapping as a list")?
             .root();

--- a/directives/src/lib.rs
+++ b/directives/src/lib.rs
@@ -83,7 +83,7 @@ impl Directives {
         match Self::once(field, fields)? {
             Some(raw_options) => {
                 let parsed = Expr::from_str(raw_options)
-                    .with_context(|| format!("could not parse `{}` as a Nix expression", field))?;
+                    .with_context(|| format!("could not parse `{field}` as a Nix expression"))?;
 
                 match parsed.kind() {
                     SyntaxKind::NODE_ATTR_SET => Ok(Some(parsed)),

--- a/nix-script-haskell/src/main.rs
+++ b/nix-script-haskell/src/main.rs
@@ -132,7 +132,7 @@ fn main() {
             std::process::exit(1)
         }
         Err(err) => {
-            eprintln!("{:?}", err);
+            eprintln!("{err:?}");
             std::process::exit(1)
         }
     }

--- a/nix-script/src/derivation/inputs.rs
+++ b/nix-script/src/derivation/inputs.rs
@@ -40,9 +40,9 @@ impl Display for Inputs {
                 done_with_first = true;
             }
 
-            write!(f, "{}", key)?;
+            write!(f, "{key}")?;
             if let Some(value) = default {
-                write!(f, " ? {}", value)?;
+                write!(f, " ? {value}")?;
             }
         }
 

--- a/nix-script/src/derivation/mod.rs
+++ b/nix-script/src/derivation/mod.rs
@@ -74,10 +74,8 @@ impl Derivation {
         for build_input in build_inputs {
             if build_input.is_extractable() {
                 log::trace!("extracting build input `{}`", build_input);
-                self.inputs.insert(
-                    build_input.to_string(),
-                    Some(format!("pkgs.{build_input}")),
-                );
+                self.inputs
+                    .insert(build_input.to_string(), Some(format!("pkgs.{build_input}")));
             }
             self.build_inputs.insert(build_input);
         }

--- a/nix-script/src/derivation/mod.rs
+++ b/nix-script/src/derivation/mod.rs
@@ -51,7 +51,7 @@ impl Derivation {
             inputs: Inputs::from(vec![
                 (
                     "pkgs".into(),
-                    Some(format!("import <nixpkgs> {}", final_nixpkgs_options)),
+                    Some(format!("import <nixpkgs> {final_nixpkgs_options}")),
                 ),
                 ("makeWrapper".into(), Some("pkgs.makeWrapper".into())),
             ]),
@@ -76,7 +76,7 @@ impl Derivation {
                 log::trace!("extracting build input `{}`", build_input);
                 self.inputs.insert(
                     build_input.to_string(),
-                    Some(format!("pkgs.{}", build_input)),
+                    Some(format!("pkgs.{build_input}")),
                 );
             }
             self.build_inputs.insert(build_input);
@@ -111,7 +111,7 @@ impl Derivation {
                 log::trace!("extracting build input `{}`", runtime_input);
                 self.inputs.insert(
                     runtime_input.to_string(),
-                    Some(format!("pkgs.{}", runtime_input)),
+                    Some(format!("pkgs.{runtime_input}")),
                 );
             }
             self.runtime_inputs.insert(runtime_input);
@@ -233,9 +233,9 @@ fn fmt_list(f: &mut fmt::Formatter<'_>, inputs: &BTreeSet<Expr>) -> Result<(), f
     write!(f, "[")?;
     for input in inputs {
         if input.needs_parens_in_list() {
-            write!(f, " ({})", input)?;
+            write!(f, " ({input})")?;
         } else {
-            write!(f, " {}", input)?;
+            write!(f, " {input}")?;
         }
     }
     write!(f, " ]")

--- a/nix-script/src/main.rs
+++ b/nix-script/src/main.rs
@@ -224,7 +224,7 @@ impl Opts {
             .hash(&directives)
             .context("could not calculate cache location for the script's compiled version")?;
 
-        let target = cache_directory.join(format!("{}-{}", hash, script_name));
+        let target = cache_directory.join(format!("{hash}-{script_name}"));
         log::trace!("cache target: {}", target.display());
 
         // before we perform the build, we need to check if the symlink target
@@ -355,7 +355,7 @@ fn main() {
             std::process::exit(1)
         }
         Err(err) => {
-            eprintln!("{:?}", err);
+            eprintln!("{err:?}");
             std::process::exit(1)
         }
     }


### PR DESCRIPTION
Building `nix-script` fails on `nixos-unstable` due to pedantic errors of the `format!` macro.

That is: `format!("{}", var)` -> `format!("{var}")`; see https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args.

This PR fixes these errors, but might break compilation with older versions of `rustc`.