### PR TITLE
flake: add cache config

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,4 +1,9 @@
 {
+  nixConfig = {
+    extra-substituters = [ "https://nix-script.cachix.org" ];
+    extra-trusted-public-keys = [ "nix-script.cachix.org-1:czo3tF6XERpkDdMd6m84XjmgeHQXNeIooSt7b0560+c=" ];
+  };
+
   inputs = {
     flake-utils.url = "github:numtide/flake-utils";
     naersk.url = "github:nix-community/naersk";


### PR DESCRIPTION
This enables nix tooling to offer to enable the cache:

```
edrex@chip ~/s/g/B/nix-script (main)> nix profile install .
do you want to allow configuration setting 'extra-substituters' to be set to 'https://nix-script.cachix.org' (y/N)? y
do you want to permanently mark this value as trusted (y/N)? y
do you want to allow configuration setting 'extra-trusted-public-keys' to be set to 'nix-script.cachix.org-1:czo3tF6XERpkDdMd6m84XjmgeHQXNeIooSt7b0560+c=' (y/N)? y
do you want to permanently mark this value as trusted (y/N)? y
```
(doesn't work for inputs, only the root flake)

I didn't get a cache hit when I just tried it though.