### PR TITLE
fix partial compare linter error

### DIFF
--- a/directives/src/expr.rs
+++ b/directives/src/expr.rs
@@ -85,7 +85,7 @@ impl Ord for Expr {
 
 impl PartialOrd for Expr {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.raw.partial_cmp(&other.raw)
+        Some(self.cmp(other))
     }
 }
 


### PR DESCRIPTION
closes #257

https://rust-lang.github.io/rust-clippy/master/index.html#/incorrect_partial_ord_impl_on_ord_type