### PR TITLE
fix compilation error with newer rust versions

### DIFF
--- a/nix-script/src/clean_path.rs
+++ b/nix-script/src/clean_path.rs
@@ -9,7 +9,7 @@ pub fn clean_path(path: &Path) -> Result<PathBuf> {
     if path.is_relative() {
         let components: Vec<Component> = path.components().collect();
 
-        match components.get(0) {
+        match components.first() {
             Some(Component::CurDir) => {
                 if components.len() == 1 {
                     Ok(PathBuf::from("./."))


### PR DESCRIPTION
Vec<...>.get(0) -> Vec<...>.first()

Fixes
```
error: builder for '/nix/store/f45n2chpgz3yc33chn9s671zry3nycgh-nix-script-2.0.0.drv' failed with exit code 101;
┃        last 10 log lines:
┃        >   --> nix-script/src/clean_path.rs:12:15
┃        >    |
┃        > 12 |         match components.get(0) {
┃        >    |               ^^^^^^^^^^^^^^^^^ help: try: `components.first()`
┃        >    |
┃        >    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#get_first
┃        >    = note: `-D clippy::get-first` implied by `-D warnings`
┃        >    = help: to override `-D warnings` add `#[allow(clippy::get_first)]`
┃        >
┃        > error: could not compile `nix-script` (bin "nix-script") due to previous error
┃        For full logs, run 'nix log /nix/store/f45n2chpgz3yc33chn9s671zry3nycgh-nix-script-2.0.0.drv'
```
on current `nixos-unstable`.