### PR TITLE
Fix build error due to clippy warning (to_owned -> clone_into)

### DIFF
--- a/directives/src/lib.rs
+++ b/directives/src/lib.rs
@@ -122,7 +122,7 @@ impl Directives {
 
     pub fn maybe_override_build_command(&mut self, maybe_new: &Option<String>) {
         if maybe_new.is_some() {
-            self.build_command = maybe_new.to_owned()
+            maybe_new.clone_into(&mut self.build_command)
         }
     }
 
@@ -140,7 +140,7 @@ impl Directives {
 
     pub fn maybe_override_interpreter(&mut self, maybe_new: &Option<String>) {
         if maybe_new.is_some() {
-            self.interpreter = maybe_new.to_owned()
+            maybe_new.clone_into(&mut self.interpreter)
         }
     }
 


### PR DESCRIPTION
Fixes two warnings leading to build errors:

```
warning: assigning the result of `ToOwned::to_owned()` may be inefficient
   --> directives/src/lib.rs:125:13
    |
125 |             self.build_command = maybe_new.to_owned()
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `clone_into()`: `maybe_new.clone_into(&mut self.build_command)`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#assigning_clones
    = note: `#[warn(clippy::assigning_clones)]` on by default

warning: assigning the result of `ToOwned::to_owned()` may be inefficient
   --> directives/src/lib.rs:143:13
    |
143 |             self.interpreter = maybe_new.to_owned()
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `clone_into()`: `maybe_new.clone_into(&mut self.interpreter)`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#assigning_clones

warning: `directives` (lib) generated 2 warnings (run `cargo clippy --fix --lib -p directives` to apply 2 suggestions)
```

There are more warnings which this PR does not fix:
```
warning: virtual workspace defaulting to `resolver = "1"` despite one or more workspace members being on edition 2021 which implies `resolver = "2"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
note: for more details see https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions
```